### PR TITLE
Add ability to use visibility modifiers

### DIFF
--- a/src/test/php/lang/ast/syntax/php/unittest/RecordsTest.class.php
+++ b/src/test/php/lang/ast/syntax/php/unittest/RecordsTest.class.php
@@ -131,4 +131,10 @@ class RecordsTest extends EmittingTest {
     }');
     $t->newInstance(5, 1);
   }
+
+  #[Test]
+  public function modifiers_can_be_used() {
+    $t= $this->type('record <T>(protected string $name) { }');
+    Assert::equals(MODIFIER_PROTECTED, $t->getField('name')->getModifiers());
+  }
 }


### PR DESCRIPTION
Like in Kotlin, we can use visibility modifiers to control the members:

```php
record User(int $id, protected string $name) {
  // ...
}
```